### PR TITLE
Create remote_release.yml

### DIFF
--- a/.github/workflows/remote_release.yml
+++ b/.github/workflows/remote_release.yml
@@ -1,0 +1,30 @@
+name: Remote Tagging
+
+on:
+  repository_dispatch:
+    types: [update-tag]
+
+permissions:
+  contents: write
+  repository-projects: write
+    
+jobs:
+  submodule:
+    name: Update submodule and create tag
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+        
+      - name: Create tag
+        run: git tag ${{ github.event.client_payload.tag }}
+        
+      - name: GitHub Push
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          # Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.MACHINE_USER_PAT }}
+          # Determines if --tags is used
+          tags: true

--- a/.github/workflows/remote_release.yml
+++ b/.github/workflows/remote_release.yml
@@ -41,3 +41,4 @@ jobs:
           github_token: ${{ secrets.MACHINE_USER_PAT }}
           # Determines if --tags is used
           tags: true
+          force: true

--- a/.github/workflows/remote_release.yml
+++ b/.github/workflows/remote_release.yml
@@ -17,7 +17,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-        
+
+      - name: Update submodule
+        run: |
+          git submodule init
+          git submodule update --recursive --remote
+          cd open-simulation-interface
+          git checkout ${{ github.event.client_payload.tag }}
+          cd ..
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add open-simulation-interface
+          git commit -m "OSI submodule updated"
+        continue-on-error: true
+
       - name: Create tag
         run: git tag ${{ github.event.client_payload.tag }}
         


### PR DESCRIPTION
Create the YML file to allow remote tagging from the open-simulation-interface repo release

Resolves https://github.com/OpenSimulationInterface/open-simulation-interface/issues/888

Signed-off-by: Ahmed Sadek ahmed.sadek@asam.net